### PR TITLE
PostgreSQL::createNotifyInsertsTrigger()

### DIFF
--- a/include/psql.h
+++ b/include/psql.h
@@ -41,11 +41,11 @@ public:
   bool	isValid() const { return(_conn ? true : false); }
 
 //@{
-  /** 
+  /**
    * Write LowRate (LRT) data into the database.
    */
   void	WriteSQL(const std::string & timeStamp);
-  /** 
+  /**
    * Write SampleRate (SRT) data into the database.
    * @returns usec of last sample written.
    */
@@ -127,6 +127,7 @@ protected:
   void grantSelectToTables(const std::string);
   void initializeGlobalAttributes();
   void initializeVariableList();
+  void createNotifyInsertsTrigger();
 
   std::string
   getGlobalAttribute(const char key[]) const;
@@ -142,7 +143,7 @@ protected:
    * Low level add a variable with given params.
    */
   void
-  addVariableToDataBase(const var_base* var, 
+  addVariableToDataBase(const var_base* var,
 	size_t nDims, const int dims[],
 	const std::vector<float>& cals, float missingValue);
 

--- a/src/filter/psql.cc
+++ b/src/filter/psql.cc
@@ -572,7 +572,6 @@ PostgreSQL::initializeVariableList()
 
 }	// END INITIALIZEVARIABLELIST
 
-
 /* -------------------------------------------------------------------- */
 int32_t
 PostgreSQL::WriteSQLvolts(const std::string & timeStamp)

--- a/src/filter/psql.cc
+++ b/src/filter/psql.cc
@@ -336,6 +336,34 @@ PostgreSQL::createNotifyInsertsTrigger()
   _sqlString.str("");
   _sqlString << R"(
 
+    --
+    -- based on https://gist.github.com/colophonemes/9701b906c5be572a40a84b08f4d2fa4e
+    --
+
+    --
+    -- notify_inserts((channel_name, optional):
+    --   Trigger notification for messaging to PG Notify
+    --
+    --   If channel_name is not specified, defaults to table_name + '_inserts'
+    --
+    --   e.g.
+    --
+    --   CREATE TRIGGER notify_inserts AFTER INSERT ON raf_lrt
+    --     FOR EACH ROW EXECUTE PROCEDURE notify_inserts();
+    --     => NOTIFY on channel 'raf_lrt_inserts'
+
+    --   CREATE TRIGGER notify_inserts AFTER INSERT ON raf_lrt
+    --     FOR EACH ROW EXECUTE PROCEDURE notify_inserts('foo');
+    --     => NOTIFY on channel 'foo'
+
+    --   Notifies channel w/ JSON hash:
+    --     - column name and value as key-value pairs
+    --     - e.g.
+    --        INSERT INTO raf_lrt(datetime, gglat, gglon,ggalt,atx) VALUES (NOW(), 4, -15,1000,32.2)
+    --
+    --        =>  {"datetime":"2019-05-07 00:28:16.149046","gglat":"4","gglon":"-15","ggalt":"1000","atx":"32.2"}
+    --
+
     CREATE OR REPLACE FUNCTION notify_inserts() RETURNS trigger AS $trigger$
       DECLARE
         rec RECORD;

--- a/src/filter/psql.cc
+++ b/src/filter/psql.cc
@@ -326,8 +326,6 @@ PostgreSQL::grantSelectToTables(const std::string user)
   submitCommand(_sqlString.str(), true);
 
 }	// END GRANTSELECTTOTABLES
-/* -------------------------------------------------------------------- */
-
 
 /* -------------------------------------------------------------------- */
 void


### PR DESCRIPTION
create and call `PostgreSQL::createNotifyInsertsTrigger(`), which:

- creates a `TRIGGER` `FUNCTION` that will `NOTIFY` a dedicated channel w/ the row's contents in JSON upin `INSERT`
- applies that trigger to the `raf_lrt` table to run after`INSERT`

(syntax looks ok, SQL has been tested w/ actual data and works, no idea if c++ code compiles or runs. huzzah.)